### PR TITLE
Revert change of BuilderId. It should be vagrant, right?

### DIFF
--- a/post-processor.go
+++ b/post-processor.go
@@ -78,8 +78,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 }
 
 func (p *PostProcessor) PostProcess(ui packer.Ui, artifact packer.Artifact) (packer.Artifact, bool, error) {
-	if artifact.BuilderId() != "mitchellh.virtualbox" {
-		return nil, false, fmt.Errorf("Unknown artifact type, requires box from vagrant post-processor: %s", artifact.BuilderId())
+	// Only accepts input from the vagrant post-processor
+	if artifact.BuilderId() != "mitchellh.post-processor.vagrant" {
+		return nil, false, fmt.Errorf(
+			"Unknown artifact type, requires box from vagrant post-processor: %s", artifact.BuilderId())
 	}
 	box := artifact.Files()[0]
 	if !strings.HasSuffix(box, ".box") {


### PR DESCRIPTION
I see this was changed over a year ago to virtualbox, but I am not sure why. The BuilderID should be mitchellh.

Fixes #8 

I am not sure why this was changed. Perhaps @kczauz can shed some light on this? 

Vagrant boxes have to come from vagrant. Maybe we need to adjust as per #8 to accept multiple sources?

~tommy